### PR TITLE
Fix handling of QueryParams.

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -320,7 +320,7 @@ mkLetParams opts request =
 
         F.List ->
             name <$>
-            indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (name <> "[]=") <+> "++ (val |> toString |> Http.encodeUri)") <$>
+            indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (elmName <> "[]=") <+> "++ (val |> toString |> Http.encodeUri)") <$>
                       "|> String.join" <+> dquotes "&")
       where
         name = elmQueryArg qarg


### PR DESCRIPTION
They were passing params named "query_foo" instead of "foo".