### PR TITLE
Replace XSRF token with XSRF buster.

### DIFF
--- a/src/Servant/Elm.hs
+++ b/src/Servant/Elm.hs
@@ -24,13 +24,14 @@ module Servant.Elm
        , specsToDir
        -- * Convenience re-exports from "Data.Proxy"
        , Proxy(Proxy)
-       , headerNameCSRF
+       , headerNameXsrfBuster
        ) where
 
 import           Servant.Elm.Internal.Generate (ElmOptions (..), UrlPrefix (..),
                                                 defElmImports, defElmOptions,
                                                 generateElmForAPI,
-                                                generateElmForAPIWith, headerNameCSRF)
+                                                generateElmForAPIWith,
+                                                headerNameXsrfBuster)
 
 import           Data.Proxy                    (Proxy (Proxy))
 import           Elm                           (ElmType, Spec (Spec),


### PR DESCRIPTION
The buster just needs to be sent with value "True". It's a custom request header, per https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Protecting_REST_Services:_Use_of_Custom_Request_Headers

This still gets the XSRF cookie, for now, because that was the minimum viable change. Will need to refactor in future.